### PR TITLE
Fix folder name for `devcontainer.json` location

### DIFF
--- a/vs-online/reference/configuring.md
+++ b/vs-online/reference/configuring.md
@@ -59,7 +59,7 @@ Start provisioning a container by including a **devcontainer.json** file in the 
 
 Add the `dockerFile` argument and value to your **devcontainer.json** to provision a custom container.
 
-Include the Dockerfile as part of the repository. We recommend placing it in the **.devcontainer.json** folder with the **devcontainer.json** file.
+Include the Dockerfile as part of the repository. We recommend placing it in the **.devcontainer** folder with the **devcontainer.json** file.
 
 ### Docker Compose support
 


### PR DESCRIPTION
👋 Hi from the GitHub docs team!

We're currently linking our Codespaces docs to here for a lot of the config, and I noticed this small error.

The folder where the `devcontainer.json` lives is named `.devcontainer`, as per the description at the start of the article. 